### PR TITLE
Issue corrected #line53

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -50,7 +50,7 @@ function wpfda_i10n_data() {
 		'ajax_url'            => admin_url( 'admin-ajax.php' ),
 		'wpfda_nonce'         => wp_create_nonce( 'wpfda_nonce' ),
 		'is_feedback_enabled' => get_option( 'wpfda_enable_feedback_email', 'no' ),
-		'redirect_url'        => get_option( 'wpfda_redirect_url' ),
+		'redirect_url' 		  => get_option( 'wpfda_redirect_url', '' ),
 		'incorrect_answer'    => esc_html__( 'Incorrect Answer. Please try again.', 'wp-frontend-delete-account' ),
 		'empty_password'      => esc_html__( 'Empty Password.', 'wp-frontend-delete-account' ),
 		'processing'          => esc_html__( 'Processing...', 'wp-frontend-delete-account' ),


### PR DESCRIPTION
In line 53, empty string will be passed instead of false. get_option() returns false if there is no option in the database so instead of passing false statement, an empty string would be passed. 'redirect_url' => get_option( 'wpfda_redirect_url' ), replaced by 'redirect_url' => get_option( 'wpfda_redirect_url', '' ), in line 53.